### PR TITLE
NativeNfcTag: Set minimum threshold for watchdogTimeout to  5000

### DIFF
--- a/nci/src/com/android/nfc/dhimpl/NativeNfcTag.java
+++ b/nci/src/com/android/nfc/dhimpl/NativeNfcTag.java
@@ -83,7 +83,11 @@ public class NativeNfcTag implements TagEndpoint {
 
         PresenceCheckWatchdog(
                 int presenceCheckDelay, @Nullable DeviceHost.TagDisconnectedCallback callback) {
+        if (presenceCheckDelay < 5000) {
+            watchdogTimeout = 5000;
+        } else {
             watchdogTimeout = presenceCheckDelay;
+        }
             tagDisconnectedCallback = callback;
         }
 


### PR DESCRIPTION
* Based on https://github.com/StarGate01/NFCPresenceFix

See https://gitlab.com/LineageOS/issues/android/-/issues/7268 :

> In short, unless the `EXTRA_READER_PRESENCE_CHECK_DELAY` bundle configuration parameter in `NFCAdapter::enableReaderMode` is set to something high like `5000 ms`, the presented smartcard will be considered lost by the AOSP `NfcNci` implementation, even though the card is still busy performing computations.

Many apps do not implement this, as the default proprietary `NQNfcNci` implementation by NXP and Qualcomm die not have this issue.